### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -1,0 +1,13 @@
+import os
+from src.meshic_pipeline.config import Settings, PIPELINE_CFG
+
+
+def test_settings_loads_yaml_values():
+    s = Settings()
+    assert s.zoom == PIPELINE_CFG["zoom"]
+
+
+def test_environment_variable_override(monkeypatch):
+    monkeypatch.setenv("TILE_BASE_URL", "http://example.com")
+    s = Settings()
+    assert s.tile_base_url == "http://example.com"

--- a/tests/unit/test_geometry_validator.py
+++ b/tests/unit/test_geometry_validator.py
@@ -1,0 +1,20 @@
+import geopandas as gpd
+from shapely.geometry import Polygon
+
+from src.meshic_pipeline.geometry.validator import validate_geometries
+
+
+def test_validate_geometries_fixes_invalid_polygon():
+    poly = Polygon([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)])
+    gdf = gpd.GeoDataFrame({"geometry": [poly]}, geometry="geometry", crs="EPSG:4326")
+
+    validated = validate_geometries(gdf)
+
+    assert not validated.empty
+    assert validated.geometry.iloc[0].is_valid
+
+
+def test_validate_geometries_empty():
+    gdf = gpd.GeoDataFrame({"geometry": []}, geometry="geometry", crs="EPSG:4326")
+    validated = validate_geometries(gdf)
+    assert validated.empty

--- a/tests/unit/test_tile_endpoint_discovery_new.py
+++ b/tests/unit/test_tile_endpoint_discovery_new.py
@@ -1,0 +1,32 @@
+import pytest
+from src.meshic_pipeline.discovery.tile_endpoint_discovery import (
+    get_tile_coordinates_for_bounds,
+    get_tile_coordinates_for_grid,
+)
+
+
+def test_get_tile_coordinates_for_bounds_single_tile():
+    bbox = (0.0, 0.0, 1.0, 1.0)
+    tiles = get_tile_coordinates_for_bounds(bbox, zoom=1)
+    assert tiles == [(1, 1, 0)]
+
+
+def test_get_tile_coordinates_for_bounds_invalid():
+    bbox = (1.0, 1.0, 0.0, 0.0)
+    tiles = get_tile_coordinates_for_bounds(bbox, zoom=1)
+    assert tiles == []
+
+
+def test_get_tile_coordinates_for_grid():
+    tiles = get_tile_coordinates_for_grid(
+        center_x=5, center_y=6, grid_w=3, grid_h=2, zoom=4
+    )
+    expected = [
+        (4, 4, 5),
+        (4, 4, 6),
+        (4, 5, 5),
+        (4, 5, 6),
+        (4, 6, 5),
+        (4, 6, 6),
+    ]
+    assert tiles == expected


### PR DESCRIPTION
## Summary
- add discovery tile generation tests
- ensure geometry validator handles invalid polygons
- verify config values load from YAML and environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868678a85488329ab8f104ba7812253