### PR TITLE
Add validator and config tests

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -267,4 +267,101 @@ git push origin main --tags
 3. **Scale Systematically**: Don't skip validation steps
 4. **Maintain Commercial Focus**: Remember this is for client products, not platform development
 
-This TODO reflects the actual current state: fresh database, proven architecture, and systematic validation approach to reach full Saudi Arabia coverage for commercial data products. 
+This TODO reflects the actual current state: fresh database, proven architecture, and systematic validation approach to reach full Saudi Arabia coverage for commercial data products.
+
+## 📘 **Comprehensive Unit Testing Plan**
+
+### 1. Objectives
+- Ensure correctness of all core utility functions and logic in isolation.
+- Catch edge cases and regressions early, before integration or pipeline runs.
+- Validate error handling, data validation, and type safety.
+- Provide a foundation for robust integration and regression testing.
+
+### 2. Scope of Unit Testing
+
+#### A. Tile Discovery & Download
+- **Functions**: Tile list generation, tile server URL construction, bounding box calculations.
+- **Tests**:
+  - Correct tile list for given bbox/zoom.
+  - URL formatting for all provinces.
+  - Edge cases such as bboxes on province boundaries and invalid input values.
+
+#### B. MVT Decoding & Geometry Processing
+- **Functions**: MVT tile decoding, geometry validation, CRS transformation, geometry stitching.
+- **Tests**:
+  - Decoding valid and invalid MVT tiles.
+  - Geometry type checks (multipolygon, no self-intersections).
+  - CRS conversion accuracy.
+  - Handling of empty or malformed tiles.
+
+#### C. Database Utility Functions
+- **Functions**: Chunked inserts, upsert key generation, type casting, reference lookups.
+- **Tests**:
+  - Chunking logic for various batch sizes.
+  - Upsert key uniqueness and error handling.
+  - Type casting for all supported DB types.
+  - Reference table lookups such as province or municipality by name.
+
+#### D. Enrichment API Client
+- **Functions**: API request construction, response parsing, error handling, retry logic.
+- **Tests**:
+  - Correct API URL and payload for all endpoints.
+  - Parsing of valid and invalid API responses.
+  - Retry logic on timeouts or 5xx errors.
+  - Handling of missing or malformed data in API responses.
+
+#### E. Data Validation Utilities
+- **Functions**: Schema validation, foreign key checks, Arabic text handling, Unicode normalization.
+- **Tests**:
+  - Validation of all expected schema fields.
+  - Foreign key relationship checks (mocked DB).
+  - Correct storage and retrieval of Arabic or other Unicode text.
+  - Handling of missing or malformed fields.
+
+#### F. Configuration & Environment
+- **Functions**: Config file parsing, environment variable overrides, validation logic.
+- **Tests**:
+  - Parsing of valid and invalid YAML configuration files.
+  - Environment variable override precedence.
+  - Validation of required config fields and types.
+
+#### G. Logging & Error Handling
+- **Functions**: Structured logging, exception wrapping, error message formatting.
+- **Tests**:
+  - Logging output for success and failure cases.
+  - Exception propagation and custom error messages.
+  - Handling of partial failures, such as a batch with some errors.
+
+### 3. Test Organization
+- **Location**: Place unit tests in `tests/unit/` or `scripts/tests/` as appropriate.
+- **Framework**: Use `pytest` for async and DB-related tests.
+- **Mocking**: Utilize `unittest.mock` or `pytest-asyncio` to mock external dependencies.
+- **Mocked Dependencies**: External APIs, DB connections, and file I/O should be mocked.
+
+### 4. Coverage Checklist
+| Area                   | Example Test Cases |
+|------------------------|-------------------|
+| Tile Discovery         | Generates correct tile list, handles edge bboxes, invalid input |
+| MVT Decoding           | Decodes valid/invalid tiles, geometry type, CRS conversion, empty tiles |
+| Geometry Processing    | Stitching, validation, error on invalid geometry |
+| DB Utilities           | Chunking, upsert key, type casting, reference lookup |
+| API Client             | URL/payload, response parsing, retry logic, error handling |
+| Data Validation        | Schema fields, FK checks, Arabic/Unicode, missing fields |
+| Config Parsing         | Valid/invalid YAML, env overrides, required fields |
+| Logging/Error Handling | Log output, exception propagation, partial failure handling |
+
+### 5. Example Test Skeletons
+Provide minimal pytest examples for each module to guide future implementations.
+
+### 6. Best Practices
+- Test all edge cases: empty input, invalid data, and boundary conditions.
+- Isolate units: mock dependencies such as the DB, APIs, and file I/O.
+- Use fixtures for common test data and setup/teardown.
+- Automate test execution in CI/CD workflows.
+- Document each test with clear coverage goals and rationale.
+
+### 7. Next Steps
+- Set up the test directory structure if not already present.
+- Identify core utility modules and functions for each area above.
+- Write initial test skeletons for each area and run them incrementally.
+- Track coverage and expand tests to cover all critical paths and edge cases.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,30 @@
+from meshic_pipeline.config import Settings, Environment
+
+
+def test_environment_override():
+    cfg = Settings(
+        database_url="postgresql://user:pass@localhost/db", environment="testing"
+    )
+    assert cfg.environment == Environment.TESTING
+
+
+def test_api_config_url_building():
+    cfg = Settings(
+        database_url="postgresql://user:pass@localhost/db",
+        api_config={"base_url": "https://example.com"},
+    )
+    api = cfg.api_config
+    assert api.transactions_url == "https://example.com/transactions"
+    assert api.building_rules_url == "https://example.com/parcel/buildingRules"
+    assert (
+        api.price_metrics_url == "https://example.com/api/parcel/metrics/priceOfMeter"
+    )
+
+
+def test_get_tile_cache_path(tmp_path):
+    cfg = Settings(
+        database_url="postgresql://user:pass@localhost/db",
+        cache_dir=tmp_path,
+    )
+    path = cfg.get_tile_cache_path(15, 1, 2)
+    assert path == tmp_path / "15" / "1" / "2.pbf"

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -1,0 +1,30 @@
+from meshic_pipeline.decoder.mvt_decoder import MVTDecoder
+import geopandas as gpd
+import shapely.geometry
+
+
+def test_decode_empty_bytes():
+    decoder = MVTDecoder()
+    assert decoder.decode_bytes(b"", 15, 0, 0) == {}
+
+
+def test_cast_property_types_basic():
+    decoder = MVTDecoder()
+    result = decoder._cast_property_types({"parcel_id": "1", "other": "abc"})
+    assert result["parcel_id"] == 1
+    assert result["other"] == "abc"
+
+
+def test_apply_arabic_column_mapping():
+    decoder = MVTDecoder()
+    gdf = gpd.GeoDataFrame(
+        {
+            "neighborhaname": ["حي"],
+            "geometry": [shapely.geometry.Point(0, 0)],
+        },
+        geometry="geometry",
+        crs="EPSG:4326",
+    )
+    mapped = decoder.apply_arabic_column_mapping(gdf)
+    assert "neighborhood_ar" in mapped.columns
+    assert "neighborhaname" not in mapped.columns

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,19 @@
+import mercantile
+from meshic_pipeline.discovery.tile_endpoint_discovery import (
+    get_tile_coordinates_for_bounds,
+    get_tile_coordinates_for_grid,
+)
+
+
+def test_get_tile_coordinates_for_bounds_round_trip():
+    bbox = (46.0, 24.0, 46.1, 24.1)
+    zoom = 15
+    tiles = get_tile_coordinates_for_bounds(bbox, zoom)
+    expected = [(t.z, t.x, t.y) for t in mercantile.tiles(*bbox, zooms=[zoom])]
+    assert tiles == expected
+
+
+def test_get_tile_coordinates_for_grid_size():
+    tiles = get_tile_coordinates_for_grid(10, 10, 3, 3, 15)
+    assert len(tiles) == 9
+    assert tiles[0] == (15, 9, 9)

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -1,0 +1,17 @@
+import geopandas as gpd
+from shapely.geometry import Polygon
+
+from meshic_pipeline.geometry.validator import validate_geometries
+
+
+def test_validate_geometries_empty():
+    gdf = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+    result = validate_geometries(gdf)
+    assert result.empty
+
+
+def test_validate_geometries_fixes_invalid():
+    poly = Polygon([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)])
+    gdf = gpd.GeoDataFrame(geometry=[poly], crs="EPSG:4326")
+    result = validate_geometries(gdf)
+    assert result.geometry.iloc[0].is_valid


### PR DESCRIPTION
## Summary
- expand unit tests for decoder, config paths and API URL building
- add geometry validator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686fc5d9708329b1594fa51ddd0106