### PR TITLE
Improve schema consistency during pipeline

### DIFF
--- a/src/meshic_pipeline/geometry/stitcher.py
+++ b/src/meshic_pipeline/geometry/stitcher.py
@@ -160,4 +160,15 @@ class GeometryStitcher:
         if final_gdf.empty:
             return gpd.GeoDataFrame(geometry=[], crs=self.target_crs)
 
+        missing_cols = [c for c in known_columns if c not in final_gdf.columns]
+        if missing_cols:
+            logger.warning(
+                "Layer '%s': Missing columns after dissolve: %s",
+                layer_name,
+                ", ".join(sorted(missing_cols)),
+            )
+            for col in missing_cols:
+                final_gdf[col] = None
+
+        final_gdf = final_gdf.reindex(columns=known_columns)
         return final_gdf.reset_index(drop=True)

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -42,3 +42,17 @@ def test_validate_and_cast_types_parcels():
     # purchase_date should be converted to datetime64
     assert pd.api.types.is_datetime64_any_dtype(result["purchase_date"])
     assert pd.isna(result.loc[1, "purchase_date"])  # invalid date becomes NaT
+
+
+def test_validate_and_cast_types_int_edge_cases():
+    data = {
+        "parcel_id": [9.0, "9.0", 9, "bad"],
+        "geometry": [Point(0, 0), Point(1, 1), Point(2, 2), Point(3, 3)],
+    }
+    gdf = gpd.GeoDataFrame(data, geometry="geometry")
+
+    persister = MockPersister()
+    result = persister._validate_and_cast_types(gdf, layer_name="parcels")
+
+    assert result["parcel_id"].tolist()[:3] == [9, 9, 9]
+    assert pd.isna(result["parcel_id"].iloc[3])

--- a/tests/unit/test_stitcher.py
+++ b/tests/unit/test_stitcher.py
@@ -1,0 +1,37 @@
+import geopandas as gpd
+from shapely.geometry import Point
+from meshic_pipeline.geometry.stitcher import GeometryStitcher
+
+class DummyPersister:
+    def create_table_from_gdf(self, gdf, table_name, known_columns=None):
+        pass
+    def write(self, gdf, layer_name, table, if_exists="append"):
+        pass
+    def read_sql(self, sql):
+        return gpd.GeoDataFrame({
+            "parcel_id": [1],
+            "geometry": [Point(0, 0)]
+        }, geometry="geometry", crs="EPSG:4326")
+    def drop_table(self, table):
+        pass
+
+def test_stitch_geometries_preserves_columns():
+    gdf = gpd.GeoDataFrame({
+        "parcel_id": [1],
+        "geometry": [Point(0, 0)]
+    }, geometry="geometry", crs="EPSG:4326")
+
+    known_columns = ["parcel_id", "missing_col", "geometry"]
+    stitcher = GeometryStitcher(target_crs="EPSG:4326", persister=DummyPersister())
+
+    result = stitcher.stitch_geometries(
+        [gdf],
+        layer_name="parcels",
+        id_column="parcel_id",
+        agg_rules={},
+        tiles=[],
+        known_columns=known_columns,
+    )
+
+    assert "missing_col" in result.columns
+    assert result["missing_col"].isna().all()


### PR DESCRIPTION
## Summary
- warn when expected columns missing after decoding
- preserve all known columns in stitched geometries
- add edge case tests for integer casting
- test column preservation in GeometryStitcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692ed859d48329afb9d28d18c71020