### PR TITLE
Make arabic column mapping static

### DIFF
--- a/src/meshic_pipeline/decoder/mvt_decoder.py
+++ b/src/meshic_pipeline/decoder/mvt_decoder.py
@@ -193,7 +193,8 @@ class MVTDecoder:
                 )
         return gdfs
 
-    def apply_arabic_column_mapping(self, gdf):
+    @staticmethod
+    def apply_arabic_column_mapping(gdf):
         """Rename all columns in the GDF according to ARABIC_COLUMN_MAP."""
         for src, dst in ARABIC_COLUMN_MAP.items():
             if src in gdf.columns:

--- a/src/meshic_pipeline/pipeline_orchestrator.py
+++ b/src/meshic_pipeline/pipeline_orchestrator.py
@@ -195,7 +195,7 @@ async def run_pipeline(
                 patched_result_list = []
                 for _layer_name, gdf in result_list:
                     # Apply Arabic column mapping centrally
-                    gdf = MVTDecoder.apply_arabic_column_mapping(None, gdf)
+                    gdf = MVTDecoder.apply_arabic_column_mapping(gdf)
                     patched_result_list.append((_layer_name, gdf))
                 decoded_gdfs_cache.append(patched_result_list)
                 for _layer_name, gdf in patched_result_list:

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -16,7 +16,6 @@ def test_cast_property_types_basic():
 
 
 def test_apply_arabic_column_mapping():
-    decoder = MVTDecoder()
     gdf = gpd.GeoDataFrame(
         {
             "neighborhaname": ["حي"],
@@ -25,6 +24,6 @@ def test_apply_arabic_column_mapping():
         geometry="geometry",
         crs="EPSG:4326",
     )
-    mapped = decoder.apply_arabic_column_mapping(gdf)
+    mapped = MVTDecoder.apply_arabic_column_mapping(gdf)
     assert "neighborhood_ar" in mapped.columns
     assert "neighborhaname" not in mapped.columns


### PR DESCRIPTION
## Summary
- make the `apply_arabic_column_mapping` method static
- update orchestrator and tests to use the new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869399b066c8329875eb225167fef3a