### PR TITLE
Fix integer casting for DB writes

### DIFF
--- a/src/meshic_pipeline/persistence/postgis_persister.py
+++ b/src/meshic_pipeline/persistence/postgis_persister.py
@@ -175,7 +175,11 @@ class PostGISPersister:
                                     except Exception:
                                         return None
                                 return None
-                            validated_gdf[col] = validated_gdf[col].apply(lambda v: robust_int(v))
+                            validated_gdf[col] = (
+                                validated_gdf[col]
+                                .apply(lambda v: robust_int(v))
+                                .astype("Int64")
+                            )
                         elif dtype == 'float64':
                             # Accept int, float, or string (parseable as float)
                             def robust_float(val):

--- a/tests/unit/test_data_validation.py
+++ b/tests/unit/test_data_validation.py
@@ -22,15 +22,15 @@ def test_validate_and_cast_types_parcels():
     persister = MockPersister()
     result = persister._validate_and_cast_types(gdf, layer_name="parcels")
 
-    # parcel_id column should convert numeric strings and floats to numbers
-    assert result.loc[0, "parcel_id"] == 10.0
-    assert result.loc[1, "parcel_id"] == 20.0
+    # parcel_id column should convert numeric strings and floats to integers
+    assert result.loc[0, "parcel_id"] == 10
+    assert result.loc[1, "parcel_id"] == 20
     assert pd.isna(result.loc[2, "parcel_id"])
 
     # zoning_id should cast fractional value to None
-    assert result.loc[0, "zoning_id"] == 1.0
+    assert result.loc[0, "zoning_id"] == 1
     assert pd.isna(result.loc[1, "zoning_id"])
-    assert result.loc[2, "zoning_id"] == 3.0
+    assert result.loc[2, "zoning_id"] == 3
 
     # transaction_price should be floats
     assert result.loc[0, "transaction_price"] == 100.5
@@ -40,3 +40,19 @@ def test_validate_and_cast_types_parcels():
     # purchase_date should be converted to datetime64
     assert pd.api.types.is_datetime64_any_dtype(result["purchase_date"])
     assert pd.isna(result.loc[1, "purchase_date"])  # invalid date becomes NaT
+
+
+def test_validate_and_cast_types_handles_bigint_strings():
+    data = {
+        "subdivision_id": ["101000319.0", 101000320.0, "not-an-int"],
+        "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+    }
+    gdf = gpd.GeoDataFrame(data, geometry="geometry")
+
+    persister = MockPersister()
+    result = persister._validate_and_cast_types(gdf, layer_name="parcels")
+
+    assert result.loc[0, "subdivision_id"] == 101000319
+    assert result.loc[1, "subdivision_id"] == 101000320
+    assert pd.isna(result.loc[2, "subdivision_id"])
+    assert str(result["subdivision_id"].dtype) == "Int64"


### PR DESCRIPTION
## Summary
- cast integer fields to pandas `Int64` type when validating before DB writes
- update data validation tests to expect true integers
- add test covering float-like BigInt IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693e4ee6e483298e0f9a3154c0d530