### PR TITLE
Secure delta enrichment queries

### DIFF
--- a/tests/unit/test_enrichment_strategies.py
+++ b/tests/unit/test_enrichment_strategies.py
@@ -1,0 +1,11 @@
+import pytest
+from meshic_pipeline.enrichment import strategies
+
+
+def test_quote_table_name_valid():
+    assert strategies._quote_table_name("valid_table") == '"valid_table"'
+
+
+def test_quote_table_name_invalid():
+    with pytest.raises(ValueError):
+        strategies._quote_table_name("bad;drop")


### PR DESCRIPTION
## Summary
- quote delta enrichment table name using SQLAlchemy's IdentifierPreparer
- add validation for table names
- test quoting helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686954ac767483299d781145c97a8ff9