### PR TITLE
Fix enrichment command references

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ The pipeline provides **multiple enrichment modes** to leverage this insight:
 
 ### **🎯 TRIGGER-BASED** (Maximum Efficiency)
 ```bash
-python fast_enrich.py trigger-based-enrich --batch-size 400
+meshic-pipeline enrich fast-enrich --batch-size 400
 ```
-- **🚀 Leverages your insight**: Only processes parcels with `transaction_price > 0`
+ - **🚀 Leverages your insight**: Only processes parcels with `transaction_price > 0`
 - **93.3% efficiency gain**: Skips 962,796 parcels that don't need enrichment
 - Perfect for post-geometric pipeline runs
 - **Use case**: Maximum efficiency, best performance
 
 ### **🆕 NEW PARCELS** (Standard Approach)
 ```bash
-python fast_enrich.py fast-enrich --batch-size 200
+meshic-pipeline enrich fast-enrich --batch-size 200
 ```
 - Processes parcels never enriched before (same as trigger-based but different implementation)
 - Perfect for initial runs or capturing new parcels
@@ -140,10 +140,10 @@ python fast_enrich.py fast-enrich --batch-size 200
 ### **🔄 INCREMENTAL UPDATES** (Weekly/Monthly) 
 ```bash
 # Weekly updates (recommended)
-python fast_enrich.py incremental-enrich --days-old 7 --batch-size 100
+meshic-pipeline enrich incremental-enrich --days-old 7 --batch-size 100
 
-# Monthly updates  
-python fast_enrich.py incremental-enrich --days-old 30 --batch-size 100
+# Monthly updates
+meshic-pipeline enrich incremental-enrich --days-old 30 --batch-size 100
 ```
 - **🎯 Captures new transactions on existing parcels**
 - Re-processes parcels not enriched recently
@@ -151,7 +151,7 @@ python fast_enrich.py incremental-enrich --days-old 30 --batch-size 100
 
 ### **🔥 FULL REFRESH** (Quarterly)
 ```bash
-python fast_enrich.py full-refresh --batch-size 50
+meshic-pipeline enrich full-refresh --batch-size 50
 ```
 - Re-processes ALL enrichable parcels
 - Guarantees 100% data completeness
@@ -160,13 +160,13 @@ python fast_enrich.py full-refresh --batch-size 50
 ### **🎯 DELTA ENRICHMENT** (Revolutionary Precision) 
 ```bash
 # Automatic workflow (recommended)
-python scripts/run_enrichment_pipeline.py delta-enrich --auto-geometric
+meshic-pipeline enrich delta-enrich --auto-geometric
 
-# Manual workflow (if fresh MVT data already exists)  
-python scripts/run_enrichment_pipeline.py delta-enrich
+# Manual workflow (if fresh MVT data already exists)
+meshic-pipeline enrich delta-enrich
 
 # Testing with limits
-python scripts/run_enrichment_pipeline.py delta-enrich --limit 100 --auto-geometric
+meshic-pipeline enrich delta-enrich --limit 100 --auto-geometric
 ```
 - **🚀 MVT-based change detection**: Only enriches parcels with actual transaction price changes
 - **Perfect precision**: No false positives from time-based approaches
@@ -193,7 +193,7 @@ python monitor_enrichment.py schedule-info
 
 | Frequency | Command | Purpose |
 |-----------|---------|---------|
-| **After Geometric** | `trigger-based-enrich` | **🚀 Maximum efficiency** - leverage transaction_price > 0 |
+| **After Geometric** | `fast-enrich` | **🚀 Maximum efficiency** - leverage transaction_price > 0 |
 | **Daily** | `fast-enrich` | Capture new parcels (standard approach) |
 | **Weekly** | `incremental-enrich --days-old 7` | **Capture new transactions** |
 | **Weekly/Monthly** | `delta-enrich --auto-geometric` | **🎯 Ultimate precision** - MVT change detection |
@@ -230,12 +230,12 @@ layers: [parcels, transactions, neighborhoods, ...]
 ### **Performance Tuning**
 ```bash
 # High-performance settings
-python fast_enrich.py incremental-enrich \
+meshic-pipeline enrich incremental-enrich \
   --batch-size 500 \
   --days-old 7
 
-# Memory-optimized settings  
-python fast_enrich.py incremental-enrich \
+# Memory-optimized settings
+meshic-pipeline enrich incremental-enrich \
   --batch-size 100 \
   --days-old 7
 ```
@@ -259,11 +259,11 @@ The pipeline **guarantees** capture of new transactions through:
 
 ### **For New Deployments**
 1. Run geometric pipeline first: `python run_pipeline.py`
-2. Run initial enrichment: `python fast_enrich.py fast-enrich`
+2. Run initial enrichment: `meshic-pipeline enrich fast-enrich`
 3. Setup monitoring: `python monitor_enrichment.py status`
 
 ### **For Ongoing Operations** 
-- **💡 LEVERAGE THE INSIGHT**: Use `trigger-based-enrich` after geometric pipeline for maximum efficiency
+- **💡 LEVERAGE THE INSIGHT**: Use `fast-enrich` after geometric pipeline for maximum efficiency
 - **Never use only `fast-enrich`** for ongoing operations - it misses new transactions on existing parcels
 - **Use `incremental-enrich`** weekly to capture new transaction data
 - **Monitor regularly** with `monitor_enrichment.py recommend`
@@ -300,7 +300,7 @@ pytest tests/geometry/
 python check_db.py
 
 # Memory issues during processing
-python fast_enrich.py incremental-enrich --batch-size 50
+meshic-pipeline enrich incremental-enrich --batch-size 50
 
 # Check enrichment status
 python monitor_enrichment.py status

--- a/src/meshic_pipeline/run_enrichment_pipeline.py
+++ b/src/meshic_pipeline/run_enrichment_pipeline.py
@@ -233,7 +233,7 @@ def delta_enrich(
 @app.command()
 def smart_pipeline_enrich(
     geometric_first: bool = typer.Option(True, "--geometric-first", help="Run geometric pipeline first"),
-    trigger_after: bool = typer.Option(True, "--trigger-after", help="Run trigger-based enrichment after geometric"),
+    trigger_after: bool = typer.Option(True, "--trigger-after", help="Run fast enrichment after geometric"),
     batch_size: int = typer.Option(300, "--batch-size", help="Enrichment batch size"),
     bbox: List[float] = typer.Option(None, "--bbox", help="Bounding box: W S E N")
 ):
@@ -247,7 +247,7 @@ def smart_pipeline_enrich(
     
     Perfect for: Complete pipeline runs, maximum efficiency and coverage
     """
-    print("🧠 Starting SMART PIPELINE with geometric + trigger-based enrichment...")
+    print("🧠 Starting SMART PIPELINE with geometric + fast enrichment...")
     
     if geometric_first:
         print("\n🗺️  STAGE 1: Running geometric pipeline...")
@@ -270,11 +270,10 @@ def smart_pipeline_enrich(
             sys.argv = original_argv
     
     if trigger_after:
-        print("\n🎯 STAGE 2: Running trigger-based enrichment...")
-        trigger_based_enrich.callback(
+        print("\n🎯 STAGE 2: Running fast enrichment...")
+        fast_enrich.callback(
             batch_size=batch_size,
             limit=None,
-            baseline_hours=2  # Only enrich parcels updated in last 2 hours (from geometric run)
         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update smart pipeline enrichment to use `fast_enrich`
- correct README examples to use `meshic-pipeline` CLI instead of the old scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686954a86dc48329b37052b375caa69e