### PR TITLE
Add memory optimization utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ meshic-pipeline enrich incremental-enrich \
   --days-old 7
 ```
 
+### Memory Management
+
+Two configuration values control memory usage:
+
+- `MAX_MEMORY_MB` – soft memory limit before garbage collection is triggered.
+- `ENABLE_MEMORY_MONITORING` – toggle automatic memory checks.
+
+Both can be set in your `.env` file or overridden with the `--max-memory` and
+`--enable-monitoring/--disable-monitoring` options of `run_geometric_pipeline.py`.
+
 ## 🎯 Critical Features for Production
 
 ### **Transaction Capture Guarantee**

--- a/src/meshic_pipeline/geometry/stitcher.py
+++ b/src/meshic_pipeline/geometry/stitcher.py
@@ -14,6 +14,7 @@ import mercantile
 from sqlalchemy import text
 
 from ..persistence.postgis_persister import PostGISPersister
+from ..memory_utils import memory_limit, get_memory_monitor
 
 logger = logging.getLogger(__name__)
 
@@ -91,8 +92,17 @@ class GeometryStitcher:
         """
 
         logger.info("Executing PostGIS dissolve for layer '%s'...", layer_name)
-        stitched_gdf = self.persister.read_sql(sql)
-        logger.info("PostGIS dissolve complete. Read back %d features.", len(stitched_gdf))
+        with memory_limit():
+            stitched_gdf = self.persister.read_sql(sql)
+
+        stats = get_memory_monitor().get_memory_stats()
+        logger.debug(
+            "PostGIS dissolve memory usage: %.2fMB", stats.process_mb
+        )
+        logger.info(
+            "PostGIS dissolve complete. Read back %d features.",
+            len(stitched_gdf),
+        )
         return stitched_gdf
 
     def stitch_geometries(

--- a/src/meshic_pipeline/run_geometric_pipeline.py
+++ b/src/meshic_pipeline/run_geometric_pipeline.py
@@ -46,6 +46,16 @@ def main(
         "--save-as-temp",
         help="Save the downloaded parcels to a temporary table with this name.",
     ),
+    max_memory: Optional[int] = typer.Option(
+        None,
+        "--max-memory",
+        help="Override memory limit in MB (default from config)",
+    ),
+    enable_monitoring: bool = typer.Option(
+        True,
+        "--enable-monitoring/--disable-monitoring",
+        help="Enable memory monitoring and automatic GC",
+    ),
 ):
     """
     🚀 Enhanced geometric processing pipeline with province discovery.
@@ -56,6 +66,11 @@ def main(
     - Province: Enhanced province discovery (--province al_qassim)
     - Saudi Arabia: All provinces (--saudi-arabia)
     """
+    # Apply memory configuration overrides
+    if max_memory is not None:
+        settings.memory_config.max_memory_usage_mb = max_memory
+    settings.memory_config.enable_memory_monitoring = enable_monitoring
+
     # Validation
     if bbox and len(bbox) != 4:
         logger.error("Bounding box must be 4 floats: min_lon min_lat max_lon max_lat")


### PR DESCRIPTION
## Summary
- add memory limit fields to configuration
- expose GC helpers in Settings
- monitor memory during tile decoding and PostGIS dissolve
- allow overriding memory settings via CLI
- document new memory options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696219e6848329b716b260ae556528