### PR TITLE
Fix gpd.read_postgis dependency in integration test

### DIFF
--- a/src/meshic_pipeline/decoder/mvt_decoder.py
+++ b/src/meshic_pipeline/decoder/mvt_decoder.py
@@ -193,8 +193,9 @@ class MVTDecoder:
                 )
         return gdfs
 
-    def apply_arabic_column_mapping(self, gdf):
-        """Rename all columns in the GDF according to ARABIC_COLUMN_MAP."""
+    @staticmethod
+    def apply_arabic_column_mapping(gdf):
+        """Rename all columns in ``gdf`` according to :data:`ARABIC_COLUMN_MAP`."""
         for src, dst in ARABIC_COLUMN_MAP.items():
             if src in gdf.columns:
                 gdf = gdf.rename(columns={src: dst})

--- a/src/meshic_pipeline/pipeline_orchestrator.py
+++ b/src/meshic_pipeline/pipeline_orchestrator.py
@@ -262,7 +262,7 @@ async def run_pipeline(
             for coords, result_list in zip(keys, pbar):
                 tiles_processed_per_layer[layer].append(coords)
                 for _layer_name, gdf in result_list:
-                    gdf = MVTDecoder.apply_arabic_column_mapping(None, gdf)
+                    gdf = MVTDecoder.apply_arabic_column_mapping(gdf)
                     gdf_standardized = gdf.reindex(columns=list(all_columns))
                     persister.write(
                         gdf_standardized, layer, temp_table, if_exists="append"

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -91,6 +91,15 @@ def test_run_pipeline_with_mocks(monkeypatch):
         DummyPersister,
     )
 
+    def dummy_read_postgis(sql, engine, geom_col="geometry"):
+        return gpd.GeoDataFrame(
+            {"parcel_id": [1], "geometry": [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])]},
+            geometry="geometry",
+            crs=settings.default_crs,
+        )
+
+    monkeypatch.setattr(gpd, "read_postgis", dummy_read_postgis)
+
     # stitcher just concatenates GeoDataFrames stored in the temp table
     def dummy_stitch(self, table_name, layer_name, id_column, agg_rules, known_columns):
         dfs = temp_tables.get(table_name, [])


### PR DESCRIPTION
## Summary
- monkeypatch `gpd.read_postgis` in the pipeline integration test to avoid using a real database
- make `apply_arabic_column_mapping` a `@staticmethod`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696b70486c83298d2e805c08998d03