### PR TITLE
Fix Pass 1 PostGIS write when schema unknown

### DIFF
--- a/src/meshic_pipeline/pipeline_orchestrator.py
+++ b/src/meshic_pipeline/pipeline_orchestrator.py
@@ -300,7 +300,14 @@ async def run_pipeline(
                 tiles_processed_per_layer[layer].append(coords)
                 for _layer_name, gdf in result_list:
                     gdf = MVTDecoder.apply_arabic_column_mapping(gdf)
-                    gdf_standardized = gdf.reindex(columns=list(all_columns))
+                    if all_columns:
+                        gdf_standardized = gdf.reindex(columns=list(all_columns))
+                    else:
+                        # During the first iteration no columns have been
+                        # discovered yet. Avoid reindexing to an empty schema
+                        # so the GeoDataFrame retains its geometry column.
+                        gdf_standardized = gdf
+
                     persister.write(
                         gdf_standardized, layer, temp_table, if_exists="append"
                     )


### PR DESCRIPTION
## Summary
- avoid calling `to_postgis` on an empty DataFrame when discovering tile schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869712f3fb48329b4a7a0e9856ed3a8