### PR TITLE
Add metrics logging for delta enrich no-op case

### DIFF
--- a/tests/unit/test_delta_enrichment_cli.py
+++ b/tests/unit/test_delta_enrichment_cli.py
@@ -1,0 +1,26 @@
+import asyncio
+from meshic_pipeline import run_enrichment_pipeline as rep
+
+
+def test_delta_enrich_no_parcels(monkeypatch, capsys):
+    async def fake_get_delta_ids_with_details(engine, table, limit):
+        return [], {}
+
+    monkeypatch.setattr(rep, "get_async_db_engine", lambda: None)
+    monkeypatch.setattr(rep, "get_delta_parcel_ids_with_details", fake_get_delta_ids_with_details)
+
+    logged = {}
+
+    def fake_info(msg, *args, **kwargs):
+        logged["msg"] = msg
+        logged["extra"] = kwargs.get("extra")
+
+    monkeypatch.setattr(rep.logger, "info", fake_info)
+
+    rep.delta_enrich(batch_size=10, limit=None, fresh_mvt_table="tmp_table", show_details=True, auto_run_geometric=False)
+
+    out = capsys.readouterr().out
+    assert "No transaction price changes detected" in out
+    assert "0 parcels" in out
+    assert logged.get("extra") is not None
+    assert logged["extra"]["metrics"]["parcels_identified_for_enrichment"] == 0


### PR DESCRIPTION
## Summary
- emit metrics and CLI summary when delta_enrich finds no parcels
- test that log call and summary output occur

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869b1db81908329ad47b3a86de9d733