### PR TITLE
Fix geometric pipeline import path

### DIFF
--- a/src/meshic_pipeline/run_enrichment_pipeline.py
+++ b/src/meshic_pipeline/run_enrichment_pipeline.py
@@ -328,7 +328,9 @@ def smart_pipeline_enrich(
     
     if geometric_first:
         print("\n🗺️  STAGE 1: Running geometric pipeline...")
-        from run_pipeline import main as run_geometric_pipeline
+        from meshic_pipeline.run_geometric_pipeline import (
+            main as run_geometric_pipeline,
+        )
         import sys
         
         # Prepare args for geometric pipeline

--- a/tests/unit/test_smart_pipeline_cli.py
+++ b/tests/unit/test_smart_pipeline_cli.py
@@ -1,0 +1,28 @@
+import types
+from typer.testing import CliRunner
+
+from meshic_pipeline.run_enrichment_pipeline import app
+import meshic_pipeline.run_enrichment_pipeline as rep
+import meshic_pipeline.run_geometric_pipeline as rgp
+
+runner = CliRunner()
+
+
+def test_smart_pipeline_enrich_runs_geometric(monkeypatch):
+    called = False
+
+    def fake_main():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(rgp, "main", fake_main)
+    monkeypatch.setattr(
+        rep.fast_enrich,
+        "callback",
+        lambda **kw: None,
+        raising=False,
+    )
+
+    result = runner.invoke(app, ["smart-pipeline-enrich"])
+    assert result.exit_code == 0
+    assert called


### PR DESCRIPTION
## Summary
- import geometric pipeline from `meshic_pipeline.run_geometric_pipeline`
- add unit test for `smart_pipeline_enrich`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0493da408329950af349f8554194