### PR TITLE
fix: use Base from persistence models

### DIFF
--- a/src/meshic_pipeline/run_enrichment_pipeline.py
+++ b/src/meshic_pipeline/run_enrichment_pipeline.py
@@ -29,7 +29,6 @@ from meshic_pipeline.persistence.models import (
 from meshic_pipeline.config import settings
 import logging
 from sqlalchemy import BigInteger, Column, DateTime, Float, Integer, String, JSON
-from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import ForeignKey
 from meshic_pipeline.exceptions import ValidationException
@@ -54,7 +53,6 @@ from rich import print as rprint
 
 logger = get_logger(__name__)
 app = typer.Typer()
-Base = declarative_base()
 
 
 def exit_with_error(summary: str, hint: str) -> None:


### PR DESCRIPTION
## Summary
- clean up `run_enrichment_pipeline` so `Base` only comes from persistence models

## Testing
- `pytest tests/unit/test_delta_enrichment_cli.py tests/unit/test_enrichment_strategies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0487bc848329b190376eaa94118a