### PR TITLE
Remove prints in mvt decoder

### DIFF
--- a/src/meshic_pipeline/decoder/mvt_decoder.py
+++ b/src/meshic_pipeline/decoder/mvt_decoder.py
@@ -59,8 +59,9 @@ class MVTDecoder:
                         if value.is_integer():
                             cast_properties[key] = int(value)
                         else:
-                            print(f"[WARN] Non-integer float for {key}: {value} in feature: {properties}")
-                            logging.warning(f"Non-integer float for {key}: {value} in feature: {properties}")
+                            logger.warning(
+                                f"Non-integer float for {key}: {value} in feature: {properties}"
+                            )
                             cast_properties[key] = None
                     elif isinstance(value, str):
                         try:
@@ -68,16 +69,19 @@ class MVTDecoder:
                             if fval.is_integer():
                                 cast_properties[key] = int(fval)
                             else:
-                                print(f"[WARN] Non-integer string for {key}: '{value}' in feature: {properties}")
-                                logging.warning(f"Non-integer string for {key}: '{value}' in feature: {properties}")
+                                logger.warning(
+                                    f"Non-integer string for {key}: '{value}' in feature: {properties}"
+                                )
                                 cast_properties[key] = None
                         except Exception:
-                            print(f"[WARN] Unparseable string for {key}: '{value}' in feature: {properties}")
-                            logging.warning(f"Unparseable string for {key}: '{value}' in feature: {properties}")
+                            logger.warning(
+                                f"Unparseable string for {key}: '{value}' in feature: {properties}"
+                            )
                             cast_properties[key] = None
                     else:
-                        print(f"[WARN] Unexpected type for {key}: {type(value)} value: {value} in feature: {properties}")
-                        logging.warning(f"Unexpected type for {key}: {type(value)} value: {value} in feature: {properties}")
+                        logger.warning(
+                            f"Unexpected type for {key}: {type(value)} value: {value} in feature: {properties}"
+                        )
                         cast_properties[key] = None
                 elif key in self.STRING_ID_FIELDS:
                     # Ensure string ID fields are strings
@@ -86,8 +90,9 @@ class MVTDecoder:
                     # Keep other fields as-is
                     cast_properties[key] = value
             except Exception as e:
-                print(f"[ERROR] Exception casting {key}: {value} in feature: {properties} -- {e}")
-                logging.error(f"Exception casting {key}: {value} in feature: {properties} -- {e}")
+                logger.error(
+                    f"Exception casting {key}: {value} in feature: {properties} -- {e}"
+                )
                 cast_properties[key] = None
         return cast_properties
 
@@ -174,8 +179,9 @@ class MVTDecoder:
             with open(quarantine_path, 'a', encoding='utf-8') as f:
                 for q in self.quarantined_features:
                     f.write(json.dumps(q, ensure_ascii=False) + '\n')
-            print(f"Quarantined {len(self.quarantined_features)} problematic features to {quarantine_path}")
-            logging.warning(f"Quarantined {len(self.quarantined_features)} problematic features to {quarantine_path}")
+            logger.warning(
+                f"Quarantined {len(self.quarantined_features)} problematic features to {quarantine_path}"
+            )
             self.quarantined_features.clear()
         
         return output_layers


### PR DESCRIPTION
## Summary
- replace console prints in `mvt_decoder` with `logger.warning`/`logger.error`
- ensure decoder no longer prints directly to stdout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b047b09e08329a47428c424d86a86