### PR TITLE
Fix semaphore timeout note and make psutil optional

### DIFF
--- a/geometric_z15_tiles_from_z10_diagnostic_report.md
+++ b/geometric_z15_tiles_from_z10_diagnostic_report.md
@@ -9,7 +9,7 @@
 
 ## 2. **Semaphore and Concurrency Control**
 - The downloader uses an `asyncio.Semaphore` to limit concurrent downloads, with the limit set by `settings.max_concurrent_downloads` (default: 20, autotuned).
-- The semaphore is correctly acquired and released, with a 30s timeout to prevent deadlocks.
+- Earlier versions imposed a 30s timeout when acquiring the semaphore. With hundreds of thousands of queued tasks, this led to mass "Timeout acquiring semaphore" errors. The timeout has been removed and `download_many` processes tiles in batches to prevent starvation.
 
 ## 3. **Autotuning Feedback Loop**
 - The `PipelineAutotuner` adjusts concurrency and batch sizes based on throughput and error counts.

--- a/src/meshic_pipeline/run_enrichment_pipeline.py
+++ b/src/meshic_pipeline/run_enrichment_pipeline.py
@@ -13,7 +13,10 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, Asyn
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from datetime import datetime, timedelta
 import time
-import psutil
+try:
+    import psutil  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    psutil = None
 
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- document removal of semaphore timeout in diagnostic report
- pass failed download count to autotuner
- make psutil optional in enrichment pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c0e98f1748329a0958f7151224346