### PR TITLE
ci: fix red test job (provide DATABASE_URL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,11 @@ jobs:
       - name: Sync dependencies (locked)
         run: uv sync --all-groups --frozen --python ${{ matrix.python-version }}
       - name: Run tests
+        env:
+          # The app instantiates Settings() at import time, which requires a valid
+          # DATABASE_URL (PostgresDsn). The test suite is fully mocked and never opens
+          # a real connection, so a well-formed dummy DSN is sufficient to let the
+          # package import and the suite collect/run. Add a `postgres` service block
+          # here (e.g. postgis/postgis image) if/when tests exercise a live database.
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/suhail_pipeline
         run: uv run pytest

--- a/tests/unit/test_geometric_cli.py
+++ b/tests/unit/test_geometric_cli.py
@@ -1,19 +1,33 @@
+import re
+
 from typer.testing import CliRunner
 from suhail_pipeline.run_geometric_pipeline import app
 
 runner = CliRunner()
+
+# Typer/Rich colourises option names in help output (e.g. in CI, FORCE_COLOR),
+# rendering "--bbox" as "\x1b[..m-\x1b[0m\x1b[..m-bbox\x1b[0m" so a literal
+# substring check fails even though the option is present. Strip ANSI first.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
 
 def test_geometric_cli_invalid_bbox():
     # Should fail with invalid bbox length
     result = runner.invoke(app, ["--bbox", "1", "2", "3"])  # Only 3 values
     assert result.exit_code != 0
     # Check both stdout and stderr for the error message
-    output = result.stdout + getattr(result, 'stderr', '')
+    output = _plain(result.stdout + getattr(result, "stderr", ""))
     assert ("Bounding box must be 4 floats" in output) or ("Usage:" in output)
+
 
 def test_geometric_cli_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "--bbox" in result.stdout
-    assert "--province" in result.stdout
-    assert "--saudi-arabia" in result.stdout 
+    out = _plain(result.stdout)
+    assert "--bbox" in out
+    assert "--province" in out
+    assert "--saudi-arabia" in out


### PR DESCRIPTION
CI's `test` job has been red since Oct 2025: the app instantiates `Settings()` (which requires `DATABASE_URL: PostgresDsn`) at import, and `ci.yml` set no `DATABASE_URL`, so pytest errored at collection (`database_url Field required`, 0 items).

Fix: set a valid dummy `DATABASE_URL` for the `Run tests` step. The suite is fully mocked (the only DB-touching test uses `DummyPersister`/`DummyInspector` and never opens a connection), so no live Postgres is needed. Verified locally by hiding `.env` and running with only the env var: `Settings()` imports and 96 tests pass.

A `postgres`/`postgis` service can be added when tests exercise a live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)